### PR TITLE
Fix missing file-extension

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -72,6 +72,11 @@ bot.onText(/\/finish\s?(png)?\s?(\d+)?/i, function (msg, match) {
                             callback(err);
                         })
                         .then(function (srcimg) {
+                            if (srcimg.indexOf('.') === -1) {
+                                var new_srcimg = srcimg + '.webp';
+                                fs.rename(srcimg, new_srcimg);
+                                srcimg = new_srcimg;
+                            }
                             console.log('[' + chatId + '] File ' + fileId + ' saved to disk.');
                             ramdb[chatId].srcimg.push(srcimg);
                             callback();


### PR DESCRIPTION
Sometimes the path given from Telegram has no extension. Now what we do, is checking if there is a dot in the filepath and if there isn't we add `.webp`.

This also fixes the missing dot in front of the file extension in the converted images.