### PR TITLE
Add missing comma in example config

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -4,7 +4,7 @@ module.exports = {
     username: 'MyAwesomeStickerBot',
 
     // binary paths
-    lottie2gif: 'lottie2gif'
+    lottie2gif: 'lottie2gif',
 
     // max images allowed in one pack
     maximages: 50,


### PR DESCRIPTION
Running the program with the example config will fail with the following error message due to the missing comma:

```
> telegram-stickerimage-bot@0.0.1 start
> node bot.js

/src/config.js:10
    maximages: 64,
    ^^^^^^^^^

SyntaxError: Unexpected identifier 'maximages'
    at wrapSafe (node:internal/modules/cjs/loader:1662:18)
    at Module._compile (node:internal/modules/cjs/loader:1704:20)
    at Object..js (node:internal/modules/cjs/loader:1895:10)
    at Module.load (node:internal/modules/cjs/loader:1465:32)
    at Function._load (node:internal/modules/cjs/loader:1282:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1487:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (/telegram-stickerimage-bot/bot.js:4:16)

Node.js v22.16.0
```